### PR TITLE
处理旋转屏幕可能导致崩溃的BUG

### DIFF
--- a/Meiqia-SDK-Demo/Meiqia-SDK-Demo.xcodeproj/project.pbxproj
+++ b/Meiqia-SDK-Demo/Meiqia-SDK-Demo.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		CCE9D1461C181399004E862E /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CCE9D1451C181399004E862E /* SystemConfiguration.framework */; };
 		CCE9D1481C18139E004E862E /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CCE9D1471C18139E004E862E /* MobileCoreServices.framework */; };
 		CCE9D14D1C1813BE004E862E /* DevelopViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CCE9D14C1C1813BE004E862E /* DevelopViewController.m */; };
+		E49C7BBF1C96A8D3003027E8 /* UIViewController+OrientationFix.m in Sources */ = {isa = PBXBuildFile; fileRef = E49C7BBE1C96A8D3003027E8 /* UIViewController+OrientationFix.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -276,6 +277,8 @@
 		CCE9D1471C18139E004E862E /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		CCE9D14B1C1813BE004E862E /* DevelopViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DevelopViewController.h; sourceTree = "<group>"; };
 		CCE9D14C1C1813BE004E862E /* DevelopViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DevelopViewController.m; sourceTree = "<group>"; };
+		E49C7BBD1C96A8D3003027E8 /* UIViewController+OrientationFix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+OrientationFix.h"; sourceTree = "<group>"; };
+		E49C7BBE1C96A8D3003027E8 /* UIViewController+OrientationFix.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+OrientationFix.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -325,6 +328,7 @@
 		CC330FDA1C33F7EA0088E648 /* MQChatViewController */ = {
 			isa = PBXGroup;
 			children = (
+				E49C7BBC1C96A8B9003027E8 /* Categories */,
 				CC868F1A1C7AFFF200BFA68D /* Vendors */,
 				CC330FDB1C33F7EA0088E648 /* Assets */,
 				CC330FDD1C33F7EA0088E648 /* Config */,
@@ -773,6 +777,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		E49C7BBC1C96A8B9003027E8 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				E49C7BBD1C96A8D3003027E8 /* UIViewController+OrientationFix.h */,
+				E49C7BBE1C96A8D3003027E8 /* UIViewController+OrientationFix.m */,
+			);
+			path = Categories;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -945,6 +958,7 @@
 				CC33109B1C33F7EA0088E648 /* MQBaseMessage.m in Sources */,
 				CC3310B31C33F7EA0088E648 /* MQChatFileUtil.m in Sources */,
 				CC3310AE1C33F7EA0088E648 /* MQBundleUtil.m in Sources */,
+				E49C7BBF1C96A8D3003027E8 /* UIViewController+OrientationFix.m in Sources */,
 				CC3310B21C33F7EA0088E648 /* MQChatEmojize.m in Sources */,
 				CC3310981C33F7EA0088E648 /* MQChatViewController.m in Sources */,
 				CCD145101C4F41DE007CA0DC /* MQEvaluationCell.m in Sources */,

--- a/Meiqia-SDK-files/MQChatViewController/Categories/UIViewController+OrientationFix.h
+++ b/Meiqia-SDK-files/MQChatViewController/Categories/UIViewController+OrientationFix.h
@@ -1,0 +1,14 @@
+//
+//  UIViewController_Orientation.h
+//  GrubbyWorm
+//
+//  Created by ian luo on 16/3/14.
+//  Copyright © 2016年 GAME-CHINA.ORG. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface UIViewController(OrientationFix)
+
+@end

--- a/Meiqia-SDK-files/MQChatViewController/Categories/UIViewController+OrientationFix.m
+++ b/Meiqia-SDK-files/MQChatViewController/Categories/UIViewController+OrientationFix.m
@@ -1,0 +1,71 @@
+//
+//  UIViewController_Orientation.m
+//  GrubbyWorm
+//
+//  Created by ian luo on 16/3/14.
+//  Copyright © 2016年 GAME-CHINA.ORG. All rights reserved.
+//
+
+#import "UIViewController+OrientationFix.h"
+
+@implementation UIViewController(OrientationFix)
+
+- (BOOL)shouldAutorotate {
+    return [self supportsLandscape] && [self supportsPortait];
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    UIInterfaceOrientationMask supportedOrientation = 0;
+    if ([self supportsLandscape]) {
+        supportedOrientation |= UIInterfaceOrientationMaskLandscape;
+    }
+    
+    if ([self supportsPortait]) {
+        supportedOrientation |= UIInterfaceOrientationMaskPortrait;
+        supportedOrientation |= UIInterfaceOrientationMaskPortraitUpsideDown;
+    }
+    
+    return supportedOrientation;
+}
+
+- (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation {
+    return [UIApplication sharedApplication].statusBarOrientation;
+}
+
+#pragma mark - private
+
+- (NSArray *)supportedOrientations {
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
+        return [[[NSBundle mainBundle] infoDictionary] valueForKey:@"UISupportedInterfaceOrientations"];
+    } else if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        return [[[NSBundle mainBundle] infoDictionary] valueForKey:@"UISupportedInterfaceOrientations~ipad"];
+    } else {
+        return @[@"UIInterfaceOrientationPortrait"];
+    }
+}
+
+- (BOOL)supportsPortait {
+    NSArray *supportedOrientation = [self supportedOrientations];
+    BOOL support = NO;
+    
+    if ([supportedOrientation containsObject:@"UIInterfaceOrientationPortrait"] ||
+        [supportedOrientation containsObject:@"UIInterfaceOrientationPortraitUpsideDown"]) {
+        support = YES;
+    }
+    
+    return support;
+}
+
+- (BOOL)supportsLandscape {
+    NSArray *supportedOrientation = [self supportedOrientations];
+    BOOL support = NO;
+    
+    if ([supportedOrientation containsObject:@"UIInterfaceOrientationLandscapeLeft"] ||
+        [supportedOrientation containsObject:@"UIInterfaceOrientationLandscapeRight"]) {
+        support = YES;
+    }
+    
+    return support;
+}
+
+@end


### PR DESCRIPTION
引入一个作用于所有UIViewController的Category：
1. 如果当前工程并不是支持所有方向，则禁止自动旋转
2. 使用当前设备的orientation作为preferred的orientation
3. 返回当前应用指定支持的orientations作为支持的orientations

使用的时候需要在应用的appDelegate里面增加
    
    func application(application: UIApplication, supportedInterfaceOrientationsForWindow window: UIWindow?) -> UIInterfaceOrientationMask {
        return UIInterfaceOrientationMask.All
    }
来打开系统对某些系统自带的ViewController旋转的支持，这些ViewController至少包括：
1. UIAlerController
2. UIImagePickerController
3. 一些私有的ViewController
这些ViewController在手机上只能以portait显示，但是在只支持的应用中，这些Controller显示的时候会触发屏幕旋转，但是由于应用并不支持横屏，从而导致崩溃，这个提交的Category的作用就是：使应用在使用手动支持所有orientation的情况下，保持原有的显示方式。