### PR TITLE
fix filename for case-sensitive filesystem

### DIFF
--- a/Meiqia-SDK-Demo/Meiqia-SDK-Demo/ViewController.m
+++ b/Meiqia-SDK-Demo/Meiqia-SDK-Demo/ViewController.m
@@ -10,7 +10,7 @@
 #import "MQChatViewManager.h"
 #import "MQChatDeviceUtil.h"
 #import "DevelopViewController.h"
-#import <MeiQiaSDK/MeiQiaSDK.h>
+#import <MeiQiaSDK/MeiqiaSDK.h>
 #import "NSArray+MQFunctional.h"
 #import "MQBundleUtil.h"
 #import "MQAssetUtil.h"

--- a/Meiqia-SDK-Demo/Meiqia-SDK-DemoTests/MQInitializationTest.m
+++ b/Meiqia-SDK-Demo/Meiqia-SDK-DemoTests/MQInitializationTest.m
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
-#import <MeiQiaSDK/MeiQiaSDK.h>
+#import <MeiQiaSDK/MeiqiaSDK.h>
 
 @interface MQInitializationTest : XCTestCase
 @property (nonatomic, strong) NSString *appKey;

--- a/Meiqia-SDK-Demo/Meiqia-SDK-DemoTests/MQOnlineTests.m
+++ b/Meiqia-SDK-Demo/Meiqia-SDK-DemoTests/MQOnlineTests.m
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
-#import <MeiQiaSDK/MeiQiaSDK.h>
+#import <MeiQiaSDK/MeiqiaSDK.h>
 
 @interface MQOnlineTests: XCTestCase
 @property (nonatomic, strong) NSString *appKey;

--- a/Meiqia-SDK-Demo/Meiqia-SDK-DemoTests/MQSendTextTests.m
+++ b/Meiqia-SDK-Demo/Meiqia-SDK-DemoTests/MQSendTextTests.m
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <MeiQiaSDK/MeiQiaSDK.h>
+#import <MeiQiaSDK/MeiqiaSDK.h>
 #import <XCTest/XCTest.h>
 
 @interface MQSendTextTests : XCTestCase

--- a/Meiqia-SDK-Demo/Meiqia-SDK-DemoTests/MQStateObserverTests.m
+++ b/Meiqia-SDK-Demo/Meiqia-SDK-DemoTests/MQStateObserverTests.m
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <MeiQiaSDK/MeiQiaSDK.h>
+#import <MeiQiaSDK/MeiqiaSDK.h>
 #import <XCTest/XCTest.h>
 
 @interface MQStateObserverTests : XCTestCase

--- a/Meiqia-SDK-files/MQChatViewController/Controllers/PreChatForm/MQPreChatCells.h
+++ b/Meiqia-SDK-files/MQChatViewController/Controllers/PreChatForm/MQPreChatCells.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "UIView+MQLayout.h"
 #import "NSArray+MQFunctional.h"
-#import <MeiqiaSDK/MeiqiaSDK.h>
+#import <MeiQiaSDK/MeiqiaSDK.h>
 
 #define TextFieldLimit 100
 

--- a/Meiqia-SDK-files/MQChatViewController/Controllers/PreChatForm/MQPreChatFormViewModel.h
+++ b/Meiqia-SDK-files/MQChatViewController/Controllers/PreChatForm/MQPreChatFormViewModel.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <MeiqiaSDK/MeiqiaSDK.h>
+#import <MeiQiaSDK/MeiqiaSDK.h>
 
 @interface MQPreChatFormViewModel : NSObject
 

--- a/Meiqia-SDK-files/MQChatViewController/Controllers/PreChatForm/MQPreChatFormViewModel.m
+++ b/Meiqia-SDK-files/MQChatViewController/Controllers/PreChatForm/MQPreChatFormViewModel.m
@@ -8,7 +8,7 @@
 
 #import "MQPreChatFormViewModel.h"
 #import "MQChatViewConfig.h"
-#import <MeiqiaSDK/MeiqiaSDK.h>
+#import <MeiQiaSDK/MeiqiaSDK.h>
 #import "MQServiceToViewInterface.h"
 #import "NSArray+MQFunctional.h"
 #import "MQChatViewConfig.h"

--- a/Meiqia-SDK-files/MQChatViewController/Controllers/PreChatForm/MQPreChatSubmitViewController.h
+++ b/Meiqia-SDK-files/MQChatViewController/Controllers/PreChatForm/MQPreChatSubmitViewController.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import <MeiqiaSDK/MeiqiaSDK.h>
+#import <MeiQiaSDK/MeiqiaSDK.h>
 #import "MQChatViewConfig.h"
 
 @interface MQPreChatSubmitViewController : UITableViewController

--- a/Meiqia-SDK-files/MQChatViewController/MessageModels/MQFileDownloadMessage.m
+++ b/Meiqia-SDK-files/MQChatViewController/MessageModels/MQFileDownloadMessage.m
@@ -7,7 +7,7 @@
 //
 
 #import "MQFileDownloadMessage.h"
-#import <MeiqiaSDK/MeiqiaSDK.h>
+#import <MeiQiaSDK/MeiqiaSDK.h>
 
 @implementation MQFileDownloadMessage
 

--- a/Meiqia-SDK-files/MQChatViewController/Vendors/VoiceConvert/amrwapper/wav.mm
+++ b/Meiqia-SDK-files/MQChatViewController/Vendors/VoiceConvert/amrwapper/wav.mm
@@ -16,7 +16,7 @@
  * -------------------------------------------------------------------
  */
 
-#import <UIKit/UIkit.h>
+#import <UIKit/UIKit.h>
 #include "wav.h"
 
 void WavWriter::writeString(const char *str) {

--- a/Meiqia-SDK-files/MQMessageForm/Controllers/MQMessageFormViewService.h
+++ b/Meiqia-SDK-files/MQMessageForm/Controllers/MQMessageFormViewService.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <MeiqiaSDK/MQEnterprise.h>
+#import <MeiQiaSDK/MQEnterprise.h>
 
 @interface MQMessageFormViewService : NSObject
 

--- a/Meiqia-SDK-files/MeiQiaSDK.framework/Headers/MQTicket.h
+++ b/Meiqia-SDK-files/MeiQiaSDK.framework/Headers/MQTicket.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016年 MeiQia Inc. All rights reserved.
 //
 
-#import <MeiQiaSDK/MeiQiaSDK.h>
+#import <MeiQiaSDK/MeiqiaSDK.h>
 
 @interface MQTickerClientInfo : MQModel
 

--- a/Meiqia-SDK-files/MeiqiaSDKViewInterface/MQServiceToViewInterface.h
+++ b/Meiqia-SDK-files/MeiqiaSDKViewInterface/MQServiceToViewInterface.h
@@ -18,7 +18,7 @@
 #import "MQBotAnswerMessage.h"
 #import "MQBotMenuMessage.h"
 #import "MQChatViewConfig.h"
-#import <MeiQiaSDK/MeiQiaSDK.h>
+#import <MeiQiaSDK/MeiqiaSDK.h>
 #import "MQFileDownloadMessage.h"
 #import "MQRichTextMessage.h"
 #import "MQBotRichTextMessage.h"

--- a/Meiqia-SDK-files/MeiqiaSDKViewInterface/MQServiceToViewInterface.m
+++ b/Meiqia-SDK-files/MeiqiaSDKViewInterface/MQServiceToViewInterface.m
@@ -7,7 +7,7 @@
 //
 
 #import "MQServiceToViewInterface.h"
-#import <MeiQiaSDK/MeiQiaSDK.h>
+#import <MeiQiaSDK/MeiqiaSDK.h>
 #import "MQBundleUtil.h"
 #import "MQChatFileUtil.h"
 #import "NSArray+MQFunctional.h"


### PR DESCRIPTION
贵司的实际文件是 <MeiQiaSDK/MeiqiaSDK.h> 但引用的时候用到了
1 MeiQiaSDK/MeiQiaSDK.h
2 MeiqiaSDK/MeiqiaSDK.h
3 MeiQiaSDK/MeiqiaSDK.h

前2种无法在 HFS case-sensitive 的文件系统下正常编译。严格来说也不是同一个文件。

不想在每次 Pod 升级后修改，希望贵司能在上游 fix。
